### PR TITLE
BUGFIX: async loading of application name on detail page

### DIFF
--- a/app/applications/[uuid]/page.tsx
+++ b/app/applications/[uuid]/page.tsx
@@ -49,7 +49,7 @@ export default function ApplicationDetailPage({ params }: any) {
         setLoadingStep('Fetching application info...');
         const res = await fetch(`/api/acquia/applications?subscriptionUuid=${subscriptionUuid}`);
         const apps = await res.json();
-        const app = Array.isArray(apps.data) ? apps.data.find((a: any) => a.uuid === typedParams.uuid) : null;
+        const app = Array.isArray(apps) ? apps.find((a: any) => a.uuid === typedParams.uuid) : null;
         setAppName(app ? app.name : '');
       } catch {
         setAppName('');


### PR DESCRIPTION
# READY FOR REVIEW

# Steps to test

1. Go to `applications/f7e9fc1b-062d-4ed8-baf7-ae33551f8934`
2. See that application name is loaded upon page load

